### PR TITLE
Fix missing include in Module.cpp

### DIFF
--- a/Module.cpp
+++ b/Module.cpp
@@ -4,6 +4,7 @@
 
 #include <yarp/os/ResourceFinder.h>
 #include <yarp/os/Property.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/sig/Vector.h>
 
 // iDynTree headers


### PR DESCRIPTION
#include <yarp/os/LogStream.h> was missing, causing a compiling error.